### PR TITLE
max lines

### DIFF
--- a/pyhole/irc.py
+++ b/pyhole/irc.py
@@ -33,6 +33,8 @@ class IRC(irclib.SimpleIRCClient):
         self.version = version
         self.conf_file = conf_file
 
+        self.max_lines = 10
+
         self.admins = config.get("admins", type="list")
         self.command_prefix = config.get("command_prefix")
         self.reconnect_delay = config.get("reconnect_delay", type="int")
@@ -151,6 +153,9 @@ class IRC(irclib.SimpleIRCClient):
                 return
 
         msg = msg.encode("utf-8").split("\n")
+        if len(msg) > self.max_lines:
+            msg = msg[0:self.max_lines-2]
+            msg.append('...')
         for line in msg:
             if self.addressed:
                 source = self.source.split("!")[0]


### PR DESCRIPTION
added max_lines instance variable to IRC, reply() checks the size of message against self.max_lines and truncates if necessary.
