### PR TITLE
Make list of IRC networks explicit

### DIFF
--- a/pyhole/irc.py
+++ b/pyhole/irc.py
@@ -404,7 +404,7 @@ def active_keywords():
 
 def main():
     """Main IRC loop."""
-    networks = CONFIG.get('networks', type='list')
+    networks = CONFIG.get("networks", type="list")
 
     LOG.info("Starting %s" % version.version_string())
     LOG.info("Connecting to IRC Networks: %s" % ", ".join(networks))

--- a/pyhole/utils.py
+++ b/pyhole/utils.py
@@ -154,6 +154,7 @@ reconnect_delay: 60
 rejoin_delay: 5
 debug: False
 plugins: admin, dice, entertainment, news, search, urls, weather
+networks: FreeNode, EFnet
 
 [Redmine]
 domain: redmine.example.com


### PR DESCRIPTION
Won't need to modify the core code when a plugin uses a new configuration section
