### PR TITLE
Move setup of logger to seperate method.

### DIFF
--- a/pyhole/client.py
+++ b/pyhole/client.py
@@ -41,7 +41,7 @@ class IRC(irclib.SimpleIRCClient):
     def __init__(self, network):
         irclib.SimpleIRCClient.__init__(self)
         network_config = utils.get_config(network)
-
+        log.setup_logger(str(network))
         self.log = log.get_logger(str(network))
         self.version = version.version_string()
         self.source = None
@@ -440,7 +440,7 @@ def active_keywords():
 def main():
     """Main IRC loop."""
     networks = CONFIG.get("networks", type="list")
-
+    log.setup_logger()
     LOG.info("Starting %s" % version.version_string())
     LOG.info("Connecting to IRC Networks: %s" % ", ".join(networks))
 

--- a/pyhole/log.py
+++ b/pyhole/log.py
@@ -19,8 +19,7 @@ import logging.handlers
 
 import utils
 
-
-def get_logger(name="Pyhole"):
+def setup_logger(name="Pyhole"):
     """Log handler"""
     debug_option = utils.get_option("debug")
     debug_config = utils.get_config().get("debug", type="bool")
@@ -41,4 +40,5 @@ def get_logger(name="Pyhole"):
     log.setFormatter(formatter)
     logging.getLogger(name).addHandler(log)
 
+def get_logger(name="Pyhole"):
     return logging.getLogger(name)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -24,6 +24,7 @@ from pyhole import utils
 class TestLog(unittest.TestCase):
     def test_logger(self):
         test_log_dir = utils.get_home_directory() + "logs/"
+        log.setup_logger(name="test")
         test_log = log.get_logger("TEST")
         self.assertEqual("TEST", test_log.name)
         self.assertEqual(test_log.level, 0)


### PR DESCRIPTION
During test coverage checking we do not have configuration available, resulting in optparse sys.exit'ing and nosetests becoming unhappy.
