### PR TITLE
Remove usage of kwargs["full_message"]

### DIFF
--- a/pyhole/plugins/kernel.py
+++ b/pyhole/plugins/kernel.py
@@ -77,7 +77,7 @@ class Kernel(plugin.Plugin):
     def _watch_for_k_bug_url(self, message, params=None, **kwargs):
         """Watch for kernel.org Bugzilla bug URLs"""
         try:
-            bug_id = kwargs["full_message"].split("id=", 1)[1].split(" ", 1)[0]
+            bug_id = message.message.split("id=", 1)[1].split(" ", 1)[0]
             self.keyword_k(message, bug_id)
         except TypeError:
             return

--- a/pyhole/plugins/launchpad.py
+++ b/pyhole/plugins/launchpad.py
@@ -79,7 +79,7 @@ class Launchpad(plugin.Plugin):
     def _watch_for_lp_bug_url(self, message, params=None, **kwargs):
         """Watch for Launchpad bug URLs"""
         try:
-            line = kwargs["full_message"].split("/")
+            line = message.message.split("/")
             for i, word in enumerate(line):
                 if word == "+bug":
                     bug_id = line[i + 1].split(" ", 1)[0]
@@ -91,7 +91,7 @@ class Launchpad(plugin.Plugin):
     def _watch_for_short_lp_bug_url(self, message, params=None, **kwargs):
         """Watch for short Launchpad bug URLs"""
         try:
-            line = kwargs["full_message"].split("/")
+            line = message.message.split("/")
             for i, word in enumerate(line):
                 if word == "bugs":
                     bug_id = line[i + 1].split(" ", 1)[0]

--- a/pyhole/plugins/redmine.py
+++ b/pyhole/plugins/redmine.py
@@ -75,7 +75,7 @@ class Redmine(plugin.Plugin):
     def _watch_for_rm_bug_url(self, message, params=None, **kwargs):
         """Watch for Redmine bug URLs"""
         try:
-            line = kwargs["full_message"].split("/")
+            line = message.message.split("/")
             for i, word in enumerate(line):
                 if word == "issues":
                     bug_id = line[i + 1].split(" ", 1)[0]

--- a/pyhole/plugins/urls.py
+++ b/pyhole/plugins/urls.py
@@ -41,7 +41,7 @@ class Url(plugin.Plugin):
     def _watch_for_url(self, message, params=None, **kwargs):
         """Watch and keep track of the latest URL"""
         try:
-            self.url = kwargs["full_message"].split(" ", 1)[0]
+            self.url = message.message.split(" ", 1)[0]
             host = self.url[7:]
 
             lookup_sites = ("open.spotify.com", "/open.spotify.com",


### PR DESCRIPTION
Conversion to message objects broke some plugins. Change to using
message.message to get the message text.

Fixes #45
