### PR TITLE
initial commit of jira plugin

### DIFF
--- a/pyhole/core/utils.py
+++ b/pyhole/core/utils.py
@@ -199,6 +199,11 @@ key: abcd1234
 domain: redmine.example.com
 key: abcd1234
 
+[Jira]
+domain: jira.example.com
+username: abcd1234
+password: pass12345
+
 [VersionOne]
 domain: www1.v1host.com
 key: EXAMPL

--- a/pyhole/plugins/jira.py
+++ b/pyhole/plugins/jira.py
@@ -1,0 +1,69 @@
+#   Copyright 2010-2011 Josh Kearney
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Pyhole Jira Plugin"""
+
+from jira import JIRA
+from pyhole.core import plugin, utils
+
+
+class Jira(plugin.Plugin):
+    """Provide access to the Jira API"""
+
+    def __init__(self, irc):
+        self.irc = irc
+        self.name = self.__class__.__name__
+        self.disabled = False
+
+        try:
+            self.jira = utils.get_config("Jira")
+            self.jira_domain = self.jira.get("domain")
+            self.jira_username = self.jira.get("username")
+            self.jira_password = self.jira.get("password")
+
+            self.jira = JIRA(self.jira_url,
+                             basic_auth=(self.jira_username,
+                                         self.jira_password))
+
+        except Exception:
+            self.disabled = True
+
+    @plugin.hook_add_keyword("jira")
+    @utils.spawn
+    def keyword_jira(self, message, params=None, **kwargs):
+        """Retrieve Jira ticket information (ex: jira NCP-1444)"""
+        if params and not self.disabled:
+            params = utils.ensure_int(params)
+            if params:
+                self._find_issue(message, params)
+
+    def _find_issue(self, message, issue_id):
+        """Find and display a Jira issue"""
+
+        try:
+            issue = self.jira.issue(issue_id)
+        except Exception:
+            return
+
+        msg = "JIRA %s #%s: %s [Status: %s, Priority: %s, Labels: %s, Assignee: %s]" % (
+            issue.fields.tracker.name,
+            issue.id,
+            issue.fields.summary,
+            issue.fields.status.name,
+            issue.fields.priority.name,
+            ",".join(issue.fields.labels),
+            issue.get("fields", {}).get("assignee", "N/A"))
+        url = "https://%s/browse/%s" % (self.jira_url, issue.key)
+
+        message.dispatch("%s %s" % (msg, url))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 BeautifulSoup==3.2.0
 Eventlet
 irc
+jira
 launchpadlib
 pywunderground
 requests


### PR DESCRIPTION
This will work for day one, but I'd like to extend `pyhole/core/plugin.py` to allow multiple keywords in `@plugin.hook_add_keyword` so a user can have multiple jira keys in their config (proj1, proj2, proj3) and each are polled for in the channel.